### PR TITLE
Add Kotest example test

### DIFF
--- a/example/demo-controller/build.gradle
+++ b/example/demo-controller/build.gradle
@@ -60,6 +60,12 @@ dependencies {
     
     testImplementation 'com.jayway.jsonpath:json-path:2.9.0'    
     testImplementation 'org.skyscreamer:jsonassert:1.5.1'
+
+    // Kotest & Mockk
+    testImplementation 'io.kotest:kotest-runner-junit5:5.8.1'
+    testImplementation 'io.kotest:kotest-assertions-core:5.8.1'
+    testImplementation 'io.mockk:mockk:1.13.10'
+    testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:0.6.8'
     
     
     // Data

--- a/example/demo-controller/src/test/kotlin/com/foo/myapp/MyControllerKotestTest.kt
+++ b/example/demo-controller/src/test/kotlin/com/foo/myapp/MyControllerKotestTest.kt
@@ -1,0 +1,23 @@
+package com.foo.myapp
+
+import com.navercorp.fixturemonkey.FixtureMonkey
+import com.navercorp.fixturemonkey.kotlin.giveMeOne
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.ui.ModelMap
+
+class MyControllerKotestTest : StringSpec({
+    "requsetBodyJson should add result to model and return main" {
+        val fixtureMonkey = FixtureMonkey.builder().build()
+        val dto = fixtureMonkey.giveMeOne<TestDto>()
+        val model = mockk<ModelMap>(relaxed = true)
+        val controller = MyController()
+
+        val viewName = controller.requsetBodyJson(dto, model)
+
+        viewName shouldBe "main"
+        verify { model.addAttribute("result", "Hello, ${dto.name}") }
+    }
+})


### PR DESCRIPTION
## Summary
- add Kotest test with Mockk and FixtureMonkey
- pull in Kotest, Mockk and FixtureMonkey dependencies

## Testing
- `gradle test --no-daemon` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684064b309a08328bb9e2ef414f24451